### PR TITLE
Fix copy construction with >=C++11

### DIFF
--- a/include/nonstd/any.hpp
+++ b/include/nonstd/any.hpp
@@ -424,7 +424,7 @@ public:
         any_REQUIRES_T( ! std::is_same<T, any>::value )
     >
     any( ValueType && value ) any_noexcept
-    : content( new holder<T>( std::move( value ) ) )
+    : content( new holder<T>( std::forward<ValueType>( value ) ) )
     {}
 
     template<

--- a/test/any.t.cpp
+++ b/test/any.t.cpp
@@ -166,6 +166,14 @@ CASE( "any: Allows to copy-construct from value" )
     EXPECT( any_cast<int>( a ) == i );
 }
 
+CASE( "any: Copy constructs from lvalue references" )
+{
+    std::string i = "Test";
+    any a( i );
+
+    EXPECT( any_cast<std::string>( a ) == i );
+}
+
 CASE( "any: Allows to move-construct from value (C++11)" )
 {
 #if any_CPP11_OR_GREATER


### PR DESCRIPTION
The universal reference of the Value&& constructor matched lvalue and
rvalue references (if they are mutable). This lead to a move in some
cases, where a copy construction was expected (at least on VS2015).

This bug hit us recently in one of our projects. I think I understood the issue correctly and this should fix it, but I don't know that much about reference collapsing and overload resolution rules and I could be wrong. The test I added does however verify my theory about the issue, but maybe I'm using any wrong?